### PR TITLE
Fix serializer KeyError while asserting Schema

### DIFF
--- a/voluptuous/schema_builder.py
+++ b/voluptuous/schema_builder.py
@@ -589,7 +589,8 @@ class Schema(object):
 
             if errors:
                 raise er.MultipleInvalid(errors)
-
+            from collections import OrderedDict
+            data = OrderedDict(data)
             out = data.__class__()
             return base_validate(path, iteritems(data), out)
 


### PR DESCRIPTION
After DRF upgrade to 3.6.4 (ymmv), serializer data uses ReturnDict which threw
error while asserting the API response data. To fix this, the hack was required
to proxy it to OrderedDict instead. Doctests fail now. But it is mostly because
the expected isn't OrderedDict format. Yet the values are correct.